### PR TITLE
Reset ev toggle

### DIFF
--- a/src/js/shared_controls.js
+++ b/src/js/shared_controls.js
@@ -577,6 +577,10 @@ function smogonAnalysis(pokemonName) {
 	return "https://smogon.com/dex/" + generation + "/pokemon/" + pokemonName.toLowerCase() + "/";
 }
 
+$(".zero-ev-toggle").change(function () {
+    $(this).closest(".poke-info").find(".set-selector").trigger("change");
+  });
+
 // auto-update set details on select
 $(".set-selector").change(function () {
 	var fullSetName = $(this).val();
@@ -645,7 +649,32 @@ $(".set-selector").change(function () {
 			$(this).closest('.poke-info').find(".tera-type-pool").hide();
 		}
 		if (regSets || randset) {
-			var set = regSets ? correctHiddenPower(setdex[pokemonName][setName]) : randset;
+			const originalSetRaw = regSets
+				? correctHiddenPower(setdex[pokemonName][setName])
+				: randset;
+
+			const pokeObj = $(this).closest(".poke-info");
+
+			// Check the checkbox state
+			const zeroEV = pokeObj.find(".zero-ev-toggle").prop("checked");
+			
+			const fullSetName = $(this).val();
+			const lastSetName = pokeObj.data("lastSetName");
+
+			if (lastSetName !== fullSetName) {
+				// New Pokemon or new set -> reset stored version
+				pokeObj.data("originalSet", JSON.parse(JSON.stringify(originalSetRaw)));
+				pokeObj.data("lastSetName", fullSetName)
+			}
+
+			// Use a deep copy of the stored original
+			const originalSet = pokeObj.data("originalSet");
+			const set = JSON.parse(JSON.stringify(originalSet)); // deep copy
+
+			// Override EVs if checkbox is checked
+			if (zeroEV) {
+				set.evs = {hp:0, atk:0, def:0, spa:0, spd:0, spe:0};
+			}
 			if (regSets) {
 				pokeObj.find(".teraType").val(set.teraType || getForcedTeraType(pokemonName) || pokemon.types[0]);
 			}

--- a/src/normal.template.html
+++ b/src/normal.template.html
@@ -135,6 +135,10 @@
     <div aria-label="Pok&eacute;mon 1" class="panel" role="region">
         <fieldset class="poke-info" id="p1">
             <legend align="center">Pok&eacute;mon 1</legend>
+            <label style:"display: block; margin-top: 0.5em;">
+                <input type="checkbox" class="zero-ev-toggle" />
+                Force all EVs to 0
+            </label>
             <input type="text" class="set-selector calc-trigger" />
             <span id="importedSetsOptions" style="width:auto; display:none">
                 <input type="checkbox" id="importedSets" /> Only show imported sets <br />
@@ -974,6 +978,10 @@
     <div aria-label="Pok&eacute;mon 2" role="region" class="panel">
         <fieldset class="poke-info" id="p2">
             <legend align="center">Pok&eacute;mon 2</legend>
+            <label style:"display: block; margin-top: 0.5em;">
+                <input type="checkbox" class="zero-ev-toggle" />
+                Force all EVs to 0
+            </label>
             <input type="text" class="set-selector calc-trigger" />
             <span id="importedSetsOptions" style="width:auto; display:none">
                 <input type="checkbox" id="importedSets" /> Only show imported sets <br />


### PR DESCRIPTION
Added toggle to browser UI to set EVs to zero in calculations. Used trigger .set-selector function for damage calculations. Deep copied original pokeObj data so that I can toggle EVs on and off. const fullSetName and lastSetName were used to ensure that switching between Pokemon sets refreshed set data.