### PR TITLE
Add trainer based pokemon filtering

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -528,3 +528,7 @@ table.field {
 .extraSetMoves {
     width: 100%;
 }
+.trainer-selector {
+    width: 100%;
+    margin-bottom: 4px;
+}

--- a/src/hardcore.template.html
+++ b/src/hardcore.template.html
@@ -135,6 +135,7 @@
     <div aria-label="Pok&eacute;mon 1" class="panel" role="region">
         <fieldset class="poke-info" id="p1">
             <legend align="center">Pok&eacute;mon 1</legend>
+            <input type="hidden" class="trainer-selector" style="width:100%; margin-bottom: 4px;" />
             <input type="text" class="set-selector calc-trigger" />
             <span id="importedSetsOptions" style="width:auto; display:none">
                 <input type="checkbox" id="importedSets" /> Only show imported sets <br />
@@ -974,6 +975,7 @@
     <div aria-label="Pok&eacute;mon 2" role="region" class="panel">
         <fieldset class="poke-info" id="p2">
             <legend align="center">Pok&eacute;mon 2</legend>
+            <input type="hidden" class="trainer-selector" style="width:100%; margin-bottom: 4px;" />
             <input type="text" class="set-selector calc-trigger" />
             <span id="importedSetsOptions" style="width:auto; display:none">
                 <input type="checkbox" id="importedSets" /> Only show imported sets <br />

--- a/src/normal.template.html
+++ b/src/normal.template.html
@@ -135,6 +135,7 @@
     <div aria-label="Pok&eacute;mon 1" class="panel" role="region">
         <fieldset class="poke-info" id="p1">
             <legend align="center">Pok&eacute;mon 1</legend>
+            <input type="hidden" class="trainer-selector" style="width:100%; margin-bottom: 4px;" />
             <input type="text" class="set-selector calc-trigger" />
             <span id="importedSetsOptions" style="width:auto; display:none">
                 <input type="checkbox" id="importedSets" /> Only show imported sets <br />
@@ -974,6 +975,7 @@
     <div aria-label="Pok&eacute;mon 2" role="region" class="panel">
         <fieldset class="poke-info" id="p2">
             <legend align="center">Pok&eacute;mon 2</legend>
+            <input type="hidden" class="trainer-selector" style="width:100%; margin-bottom: 4px;" />
             <input type="text" class="set-selector calc-trigger" />
             <span id="importedSetsOptions" style="width:auto; display:none">
                 <input type="checkbox" id="importedSets" /> Only show imported sets <br />


### PR DESCRIPTION
# Summary

This PR adds the ability to filter Pokémon sets by trainer name in the damage calculator. If "Only show imported sets" is checked that takes priority and will show over the trainer filter.

<details>
<summary>📸 Screenshots</summary>
<img width="448" height="665" alt="image" src="https://github.com/user-attachments/assets/7be079bb-9325-4e21-b57a-26c2765bafdf" />

</details>

## Testing

My branch is [deployed  and testable here](https://calc.poetril.games/hardcore?mode=hardcore) 